### PR TITLE
feat: add support for OpenAI API key via environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,6 +3330,7 @@ dependencies = [
  "signal-hook",
  "strum 0.27.1",
  "strum_macros 0.27.1",
+ "tempfile",
  "textwrap",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,6 @@ inherits = "release"
 lto = "thin"
 
 [patch]
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ In Sharad Ratatui, the role of the GM is handled by a mix of AI for the Narratio
 
 To play Sharad Ratatui, you will need an OpenAI API Key. This key is necessary to enable the game's narrative generation and other dynamic features. If you don't have an API key but still want to contribute, you can contact the maintainer to get sponsored.
 
+You can provide your API key in two ways:
+
+1. **Environment Variable** (recommended): Set the `OPENAI_API_KEY` environment variable
+2. **In-game Settings**: Enter your API key through the game's settings menu
+
 ## 🛠️ Project Architecture Overview
 
 The project is organized into several key modules, each responsible for different aspects of the game:
@@ -46,9 +51,33 @@ The game is built using the [Ratatui](https://github.com/tui-rs-revival/ratatui)
 1. Clone the repository
 2. Install Rust if you haven't already (`https://www.rust-lang.org/tools/install`)
 3. Obtain an OpenAI API Key from the [OpenAI website](https://beta.openai.com/signup/)
-4. Run `cargo build` to compile the project
-5. Start the game with `cargo run`
-6. Go to settings and set your API key
+4. Set your API key using one of these methods:
+   - **Option A (Recommended)**: Set environment variable: `export OPENAI_API_KEY=your_api_key_here`
+   - **Option B**: Run the game and enter your API key in the settings menu
+5. Run `cargo build` to compile the project
+6. Start the game with `cargo run`
+
+### Environment Variable Examples
+
+**Unix/Linux/macOS:**
+
+```bash
+export OPENAI_API_KEY=sk-openai-key
+```
+
+**Windows PowerShell:**
+
+```powershell
+$env:OPENAI_API_KEY="sk-openai-key"
+```
+
+**Windows Command Prompt:**
+
+```cmd
+set OPENAI_API_KEY=sk-openai-key
+```
+
+The environment variable takes precedence over the settings file.
 
 ## 🤝 How to Contribute
 


### PR DESCRIPTION
This pull request introduces support for overriding the OpenAI API key via an environment variable, updates documentation to reflect these changes, and adds tests to ensure the new functionality works as intended. The most important changes include the addition of environment variable precedence in settings, updates to the `README.md` for user guidance, and new tests for the settings behavior.